### PR TITLE
adding issue tracker url to README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -20,4 +20,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+== Issue Tracker
 
+Report any issues via Opscode Jira instance at http://tickets.opscode.com against Chef project.


### PR DESCRIPTION
Since this project does not use github issues it is not clear for users where to report issues. When I contacted Christopher with one issue he used opscode jira tracker, so I'm adding it to README to make things clearer.
