### PR TITLE
X-Ops-Authorization headers reconstruction bug fix

### DIFF
--- a/lib/mixlib/authentication/http_authentication_request.rb
+++ b/lib/mixlib/authentication/http_authentication_request.rb
@@ -66,7 +66,8 @@ module Mixlib
 
       def request_signature
         unless @request_signature
-          @request_signature = headers.find_all { |h| h[0].to_s =~ /^x_ops_authorization_/ }.sort { |x,y| x.to_s <=> y.to_s}.map { |i| i[1] }.join("\n")
+          @request_signature = headers.find_all { |h| h[0].to_s =~ /^x_ops_authorization_/ }
+            .sort { |x,y| x.to_s[/d+/].to_i <=> y.to_s[/d+/].to_i}.map { |i| i[1] }.join("\n")
           Mixlib::Authentication::Log.debug "Reconstituted (user-supplied) request signature: #{@request_signature}"
         end
         @request_signature

--- a/lib/mixlib/authentication/http_authentication_request.rb
+++ b/lib/mixlib/authentication/http_authentication_request.rb
@@ -67,7 +67,7 @@ module Mixlib
       def request_signature
         unless @request_signature
           @request_signature = headers.find_all { |h| h[0].to_s =~ /^x_ops_authorization_/ }
-            .sort { |x,y| x.to_s[/d+/].to_i <=> y.to_s[/d+/].to_i}.map { |i| i[1] }.join("\n")
+            .sort { |x,y| x.to_s[/\d+/].to_i <=> y.to_s[/\d+/].to_i }.map { |i| i[1] }.join("\n")
           Mixlib::Authentication::Log.debug "Reconstituted (user-supplied) request signature: #{@request_signature}"
         end
         @request_signature


### PR DESCRIPTION
It's possible that a request contains more than nine headers like "x_ops_authorization_n".
In this case headers will be sorted in the wrong way. The first will be "x_ops_authorization_1",
the second "x_ops_authorization_10" and so on. So that request signature transferred by parts in "x_ops_authorization_n" headers will be reconstructed in wrong way. So that authentication will fail.