### PR TITLE
Cleanup mixlib-authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 pkg/
 *.swp
+
+Gemfile.lock

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
 --colour
--f s

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+langauge: ruby
+rvm:
+  - 2.0
+  - 2.1
+  - 2.2
+
+branches:
+  only:
+  - master

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source "https://rubygems.org"
 gemspec
+
+gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
 source "https://rubygems.org"
 gemspec
-
-gem 'rake'

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ task :default => :spec
 desc "Run specs"
 RSpec::Core::RakeTask.new do |t|
   t.pattern = 'spec/**/*_spec.rb'
-  t.rspec_opts = %w(--color)
+  t.rspec_opts = %w(--format documentation --color)
 end
 
 gem_spec = eval(File.read("mixlib-authentication.gemspec"))

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 require 'rubygems/specification'
 require 'date'
 require 'rspec/core/rake_task'
@@ -16,12 +16,12 @@ task :default => :spec
 desc "Run specs"
 RSpec::Core::RakeTask.new do |t|
   t.pattern = 'spec/**/*_spec.rb'
-  t.rspec_opts = %w(-fs --color)
+  t.rspec_opts = %w(--color)
 end
 
 gem_spec = eval(File.read("mixlib-authentication.gemspec"))
 
-Rake::GemPackageTask.new(gem_spec) do |pkg|
+Gem::PackageTask.new(gem_spec) do |pkg|
   pkg.gem_spec = gem_spec
 end
 

--- a/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/mixlib/authentication/signedheaderauth.rb
@@ -65,7 +65,14 @@ module Mixlib
       # These parameters are accepted but not used in the computation of the signature.
       # * `:host`: The host part of the URI
       def self.signing_object(args={ })
-        SigningObject.new(args[:http_method], args[:path], args[:body], args[:host], args[:timestamp], args[:user_id], args[:file], args[:proto_version])
+        SigningObject.new(args[:http_method],
+                          args[:path],
+                          args[:body],
+                          args[:host],
+                          args[:timestamp],
+                          args[:user_id],
+                          args[:file],
+                          args[:proto_version])
       end
 
       def algorithm

--- a/lib/mixlib/authentication/version.rb
+++ b/lib/mixlib/authentication/version.rb
@@ -1,0 +1,21 @@
+# Copyright:: Copyright (c) 2010-2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Mixlib
+  module Authentication
+    VERSION = '1.3.0'
+  end
+end

--- a/mixlib-authentication.gemspec
+++ b/mixlib-authentication.gemspec
@@ -1,8 +1,9 @@
-MIXLIB_AUTHN_VERSION = '1.3.0'
+$:.unshift(File.dirname(__FILE__) + '/lib')
+require 'mixlib/authentication/version'
 
 Gem::Specification.new do |s|
   s.name = "mixlib-authentication"
-  s.version = MIXLIB_AUTHN_VERSION
+  s.version = Mixlib::Authentication::VERSION
   s.platform = Gem::Platform::RUBY
   s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc", "LICENSE", 'NOTICE']
@@ -11,14 +12,13 @@ Gem::Specification.new do |s|
   s.author = "Opscode, Inc."
   s.email = "info@opscode.com"
   s.homepage = "http://www.opscode.com"
-  
+
   # Uncomment this to add a dependency
   s.add_dependency "mixlib-log"
-  
+
   s.require_path = 'lib'
   s.files = %w(LICENSE README.rdoc Gemfile Rakefile NOTICE) + Dir.glob("*.gemspec") +
       Dir.glob("{lib,spec}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 
   %w(rspec-core rspec-expectations rspec-mocks).each { |gem| s.add_dependency gem, "~> 3.2" }
 end
-

--- a/mixlib-authentication.gemspec
+++ b/mixlib-authentication.gemspec
@@ -18,5 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.files = %w(LICENSE README.rdoc Gemfile Rakefile NOTICE) + Dir.glob("*.gemspec") +
       Dir.glob("{lib,spec}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
+
+  %w(rspec-core rspec-expectations rspec-mocks).each { |gem| s.add_dependency gem, "~> 3.2" }
 end
 

--- a/mixlib-authentication.gemspec
+++ b/mixlib-authentication.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
       Dir.glob("{lib,spec}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 
   %w(rspec-core rspec-expectations rspec-mocks).each { |gem| s.add_dependency gem, "~> 3.2" }
+  s.add_development_dependency "rake", "~> 10.4"
 end

--- a/spec/mixlib/authentication/http_authentication_request_spec.rb
+++ b/spec/mixlib/authentication/http_authentication_request_spec.rb
@@ -76,41 +76,41 @@ describe Mixlib::Authentication::HTTPAuthenticationRequest do
                 :x_ops_authorization_4=>"IWPZDHSiPcw//AYNgW1CCDptt+UFuaFYbtqZegcBd2n/jzcWODA7zL4KWEUy",
                 :x_ops_authorization_5=>"9q4rlh/+1tBReg60QdsmDRsw/cdO1GZrKtuCwbuD4+nbRdVBKv72rqHX9cu0",
                 :x_ops_authorization_6=>"utju9jzczCyB+sSAQWrxSsXB/b8vV2qs0l4VD2ML+w=="}
-    @http_authentication_request.headers.should == expected
+    expect(@http_authentication_request.headers).to eq(expected)
   end
 
   it "raises an error when not all required headers are given" do
     @merb_headers.delete("HTTP_X_OPS_SIGN")
     exception = Mixlib::Authentication::MissingAuthenticationHeader
-    lambda{ Mixlib::Authentication::HTTPAuthenticationRequest.new(@request) }.should raise_error(exception)
+    expect{ Mixlib::Authentication::HTTPAuthenticationRequest.new(@request) }.to raise_error(exception)
   end
 
   it "extracts the path from the request" do
-    @http_authentication_request.path.should == '/nodes'
+    expect(@http_authentication_request.path).to eq('/nodes')
   end
 
   it "extracts the request method from the request" do
-    @http_authentication_request.http_method.should == 'POST'
+    expect(@http_authentication_request.http_method).to eq('POST')
   end
 
   it "extracts the signing description from the request headers" do
-    @http_authentication_request.signing_description.should == 'version=1.0'
+    expect(@http_authentication_request.signing_description).to eq('version=1.0')
   end
 
   it "extracts the user_id from the request headers" do
-    @http_authentication_request.user_id.should == 'spec-user'
+    expect(@http_authentication_request.user_id).to eq('spec-user')
   end
 
   it "extracts the timestamp from the request headers" do
-    @http_authentication_request.timestamp.should == "2009-01-01T12:00:00Z"
+    expect(@http_authentication_request.timestamp).to eq("2009-01-01T12:00:00Z")
   end
 
   it "extracts the host from the request headers" do
-    @http_authentication_request.host.should == "127.0.0.1"
+    expect(@http_authentication_request.host).to eq("127.0.0.1")
   end
 
   it "extracts the content hash from the request headers" do
-    @http_authentication_request.content_hash.should == "DFteJZPVv6WKdQmMqZUQUumUyRs="
+    expect(@http_authentication_request.content_hash).to eq("DFteJZPVv6WKdQmMqZUQUumUyRs=")
   end
 
   it "rebuilds the request signature from the headers" do
@@ -122,7 +122,7 @@ IWPZDHSiPcw//AYNgW1CCDptt+UFuaFYbtqZegcBd2n/jzcWODA7zL4KWEUy
 9q4rlh/+1tBReg60QdsmDRsw/cdO1GZrKtuCwbuD4+nbRdVBKv72rqHX9cu0
 utju9jzczCyB+sSAQWrxSsXB/b8vV2qs0l4VD2ML+w==
 SIG
-    @http_authentication_request.request_signature.should == expected.chomp
+    expect(@http_authentication_request.request_signature).to eq(expected.chomp)
   end
 
 end

--- a/spec/mixlib/authentication/mixlib_authentication_spec.rb
+++ b/spec/mixlib/authentication/mixlib_authentication_spec.rb
@@ -109,15 +109,15 @@ describe "Mixlib::Authentication::SignedHeaderAuth" do
   end
 
   it "should choke when signing a request for a long user id with version 1.0" do
-    expect { LONG_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha1', '1.0') }.to raise_error
+    expect { LONG_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha1', '1.0') }.to raise_error(OpenSSL::PKey::RSAError)
   end
 
   it "should choke when signing a request with a bad version" do
-    expect { V1_1_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha1', 'poo') }.to raise_error
+    expect { V1_1_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha1', 'poo') }.to raise_error(Mixlib::Authentication::AuthenticationError)
   end
 
   it "should choke when signing a request with a bad algorithm" do
-    expect { V1_1_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha_poo', '1.1') }.to raise_error
+    expect { V1_1_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha_poo', '1.1') }.to raise_error(Mixlib::Authentication::AuthenticationError)
   end
 
 end

--- a/spec/mixlib/authentication/mixlib_authentication_spec.rb
+++ b/spec/mixlib/authentication/mixlib_authentication_spec.rb
@@ -72,22 +72,22 @@ describe "Mixlib::Authentication::SignedHeaderAuth" do
 
   it "should generate the correct string to sign and signature, version 1.0 (default)" do
 
-    V1_0_SIGNING_OBJECT.canonicalize_request.should == V1_0_CANONICAL_REQUEST
+    expect(V1_0_SIGNING_OBJECT.canonicalize_request).to eq(V1_0_CANONICAL_REQUEST)
 
     # If you need to regenerate the constants in this test spec, print out
     # the results of res.inspect and copy them as appropriate into the
     # the constants in this file.
-    V1_0_SIGNING_OBJECT.sign(PRIVATE_KEY).should == EXPECTED_SIGN_RESULT_V1_0
+    expect(V1_0_SIGNING_OBJECT.sign(PRIVATE_KEY)).to eq(EXPECTED_SIGN_RESULT_V1_0)
   end
 
   it "should generate the correct string to sign and signature, version 1.1" do
-    V1_1_SIGNING_OBJECT.proto_version.should == "1.1"
-    V1_1_SIGNING_OBJECT.canonicalize_request.should == V1_1_CANONICAL_REQUEST
+    expect(V1_1_SIGNING_OBJECT.proto_version).to eq("1.1")
+    expect(V1_1_SIGNING_OBJECT.canonicalize_request).to eq(V1_1_CANONICAL_REQUEST)
 
     # If you need to regenerate the constants in this test spec, print out
     # the results of res.inspect and copy them as appropriate into the
     # the constants in this file.
-    V1_1_SIGNING_OBJECT.sign(PRIVATE_KEY).should == EXPECTED_SIGN_RESULT_V1_1
+    expect(V1_1_SIGNING_OBJECT.sign(PRIVATE_KEY)).to eq(EXPECTED_SIGN_RESULT_V1_1)
   end
 
   it "should generate the correct string to sign and signature for non-default proto version when used as a mixin" do
@@ -95,29 +95,29 @@ describe "Mixlib::Authentication::SignedHeaderAuth" do
     version = '1.1'
 
     V1_1_SIGNING_OBJECT.proto_version = "1.0"
-    V1_1_SIGNING_OBJECT.proto_version.should == "1.0"
-    V1_1_SIGNING_OBJECT.canonicalize_request(algorithm, version).should == V1_1_CANONICAL_REQUEST
+    expect(V1_1_SIGNING_OBJECT.proto_version).to eq("1.0")
+    expect(V1_1_SIGNING_OBJECT.canonicalize_request(algorithm, version)).to eq(V1_1_CANONICAL_REQUEST)
 
     # If you need to regenerate the constants in this test spec, print out
     # the results of res.inspect and copy them as appropriate into the
     # the constants in this file.
-    V1_1_SIGNING_OBJECT.sign(PRIVATE_KEY, algorithm, version).should == EXPECTED_SIGN_RESULT_V1_1
+    expect(V1_1_SIGNING_OBJECT.sign(PRIVATE_KEY, algorithm, version)).to eq(EXPECTED_SIGN_RESULT_V1_1)
   end
 
   it "should not choke when signing a request for a long user id with version 1.1" do
-    lambda { LONG_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha1', '1.1') }.should_not raise_error
+    expect { LONG_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha1', '1.1') }.not_to raise_error
   end
 
   it "should choke when signing a request for a long user id with version 1.0" do
-    lambda { LONG_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha1', '1.0') }.should raise_error
+    expect { LONG_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha1', '1.0') }.to raise_error
   end
 
   it "should choke when signing a request with a bad version" do
-    lambda { V1_1_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha1', 'poo') }.should raise_error
+    expect { V1_1_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha1', 'poo') }.to raise_error
   end
 
   it "should choke when signing a request with a bad algorithm" do
-    lambda { V1_1_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha_poo', '1.1') }.should raise_error
+    expect { V1_1_SIGNING_OBJECT.sign(PRIVATE_KEY, 'sha_poo', '1.1') }.to raise_error
   end
 
 end
@@ -134,11 +134,11 @@ describe "Mixlib::Authentication::SignatureVerification" do
       { "size"=>MockFile.length, "content_type"=>"application/octet-stream", "filename"=>"zsh.tar.gz", "tempfile"=>MockFile.new }
 
     mock_request = MockRequest.new(PATH, request_params, MERB_HEADERS_V1_1, "")
-    Time.should_receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ)
+    expect(Time).to receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ)
 
     service = Mixlib::Authentication::SignatureVerification.new
     res = service.authenticate_user_request(mock_request, @user_private_key)
-    res.should_not be_nil
+    expect(res).not_to be_nil
   end
 
   it "should authenticate a File-containing request from a v1.0 client - Passenger" do
@@ -146,29 +146,29 @@ describe "Mixlib::Authentication::SignatureVerification" do
     request_params["tarball"] = MockFile.new
 
     mock_request = MockRequest.new(PATH, request_params, PASSENGER_HEADERS_V1_0, "")
-    Time.should_receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ)
+    expect(Time).to receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ)
 
     auth_req = Mixlib::Authentication::SignatureVerification.new
     res = auth_req.authenticate_user_request(mock_request, @user_private_key)
-    res.should_not be_nil
+    expect(res).not_to be_nil
   end
 
   it "should authenticate a normal (post body) request - Merb" do
     mock_request = MockRequest.new(PATH, MERB_REQUEST_PARAMS, MERB_HEADERS_V1_1, BODY)
-    Time.should_receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ)
+    expect(Time).to receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ)
 
     service = Mixlib::Authentication::SignatureVerification.new
     res = service.authenticate_user_request(mock_request, @user_private_key)
-    res.should_not be_nil
+    expect(res).not_to be_nil
   end
 
   it "should authenticate a normal (post body) request from a v1.0 client - Merb" do
     mock_request = MockRequest.new(PATH, MERB_REQUEST_PARAMS, MERB_HEADERS_V1_0, BODY)
-    Time.should_receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ)
+    expect(Time).to receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ)
 
     service = Mixlib::Authentication::SignatureVerification.new
     res = service.authenticate_user_request(mock_request, @user_private_key)
-    res.should_not be_nil
+    expect(res).not_to be_nil
   end
 
   it "shouldn't authenticate if an Authorization header is missing" do
@@ -180,12 +180,12 @@ describe "Mixlib::Authentication::SignatureVerification" do
     #Time.stub!(:now).and_return(TIMESTAMP_OBJ)
 
     auth_req = Mixlib::Authentication::SignatureVerification.new
-    lambda {auth_req.authenticate_user_request(mock_request, @user_private_key)}.should raise_error(Mixlib::Authentication::AuthenticationError)
+    expect {auth_req.authenticate_user_request(mock_request, @user_private_key)}.to raise_error(Mixlib::Authentication::AuthenticationError)
 
-    auth_req.should_not be_a_valid_request
-    auth_req.should_not be_a_valid_timestamp
-    auth_req.should_not be_a_valid_signature
-    auth_req.should_not be_a_valid_content_hash
+    expect(auth_req).not_to be_a_valid_request
+    expect(auth_req).not_to be_a_valid_timestamp
+    expect(auth_req).not_to be_a_valid_signature
+    expect(auth_req).not_to be_a_valid_content_hash
   end
 
 
@@ -194,44 +194,44 @@ describe "Mixlib::Authentication::SignatureVerification" do
     headers["HTTP_X_OPS_CONTENT_HASH"] += "_"
 
     mock_request = MockRequest.new(PATH, MERB_REQUEST_PARAMS, headers, BODY)
-    Time.should_receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ)
+    expect(Time).to receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ)
 
     auth_req = Mixlib::Authentication::SignatureVerification.new
     res = auth_req.authenticate_user_request(mock_request, @user_private_key)
-    res.should be_nil
+    expect(res).to be_nil
 
-    auth_req.should_not be_a_valid_request
-    auth_req.should be_a_valid_timestamp
-    auth_req.should be_a_valid_signature
-    auth_req.should_not be_a_valid_content_hash
+    expect(auth_req).not_to be_a_valid_request
+    expect(auth_req).to be_a_valid_timestamp
+    expect(auth_req).to be_a_valid_signature
+    expect(auth_req).not_to be_a_valid_content_hash
   end
 
   it "shouldn't authenticate if the timestamp is not within bounds" do
     mock_request = MockRequest.new(PATH, MERB_REQUEST_PARAMS, MERB_HEADERS_V1_1, BODY)
-    Time.should_receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ - 1000)
+    expect(Time).to receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ - 1000)
 
     auth_req = Mixlib::Authentication::SignatureVerification.new
     res = auth_req.authenticate_user_request(mock_request, @user_private_key)
-    res.should be_nil
-    auth_req.should_not be_a_valid_request
-    auth_req.should_not be_a_valid_timestamp
-    auth_req.should be_a_valid_signature
-    auth_req.should be_a_valid_content_hash
+    expect(res).to be_nil
+    expect(auth_req).not_to be_a_valid_request
+    expect(auth_req).not_to be_a_valid_timestamp
+    expect(auth_req).to be_a_valid_signature
+    expect(auth_req).to be_a_valid_content_hash
   end
 
   it "shouldn't authenticate if the signature is wrong" do
     headers =  MERB_HEADERS_V1_1.dup
     headers["HTTP_X_OPS_AUTHORIZATION_1"] = "epicfail"
     mock_request = MockRequest.new(PATH, MERB_REQUEST_PARAMS, headers, BODY)
-    Time.should_receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ)
+    expect(Time).to receive(:now).at_least(:once).and_return(TIMESTAMP_OBJ)
 
     auth_req = Mixlib::Authentication::SignatureVerification.new
     res = auth_req.authenticate_user_request(mock_request, @user_private_key)
-    res.should be_nil
-    auth_req.should_not be_a_valid_request
-    auth_req.should_not be_a_valid_signature
-    auth_req.should be_a_valid_timestamp
-    auth_req.should be_a_valid_content_hash
+    expect(res).to be_nil
+    expect(auth_req).not_to be_a_valid_request
+    expect(auth_req).not_to be_a_valid_signature
+    expect(auth_req).to be_a_valid_timestamp
+    expect(auth_req).to be_a_valid_content_hash
   end
 
 end

--- a/spec/mixlib/authentication/mixlib_authentication_spec.rb
+++ b/spec/mixlib/authentication/mixlib_authentication_spec.rb
@@ -176,7 +176,8 @@ describe "Mixlib::Authentication::SignatureVerification" do
     headers.delete("HTTP_X_OPS_SIGN")
 
     mock_request = MockRequest.new(PATH, MERB_REQUEST_PARAMS, headers, BODY)
-    Time.stub!(:now).and_return(TIMESTAMP_OBJ)
+    allow(Time).to receive(:now).and_return(TIMESTAMP_OBJ)
+    #Time.stub!(:now).and_return(TIMESTAMP_OBJ)
 
     auth_req = Mixlib::Authentication::SignatureVerification.new
     lambda {auth_req.authenticate_user_request(mock_request, @user_private_key)}.should raise_error(Mixlib::Authentication::AuthenticationError)


### PR DESCRIPTION
This cleanup does a couple things:
- Updates the Rakefile to work with current versions of rake
- Add a gemfile
- Specify test dependencies in gemspec
- Update rspec tests to use expect syntax
- Add a version.rb
- Add travis.yml