### PR TITLE
Add signing version 1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,6 @@
 source "https://rubygems.org"
 gemspec
+
+group(:development) do
+  gem 'pry'
+end

--- a/lib/mixlib/authentication.rb
+++ b/lib/mixlib/authentication.rb
@@ -20,6 +20,8 @@ require 'mixlib/log'
 
 module Mixlib
   module Authentication
+    DEFAULT_SERVER_API_VERSION = '0'
+
     class AuthenticationError < StandardError
     end
 

--- a/lib/mixlib/authentication/digester.rb
+++ b/lib/mixlib/authentication/digester.rb
@@ -21,11 +21,10 @@ require 'mixlib/authentication'
 module Mixlib
   module Authentication
     class Digester
-      
       class << self
-        
-        def hash_file(f)
-          digester = Digest::SHA1.new
+
+        def hash_file(digest, f)
+          digester = digest.new
           buf = ""
           while f.read(16384, buf)
             digester.update buf
@@ -34,15 +33,15 @@ module Mixlib
         end
 
         # Digests a string, base64's and chomps the end
-        # 
+        #
         # ====Parameters
-        # 
-        def hash_string(str)
-          ::Base64.encode64(Digest::SHA1.digest(str)).chomp
+        #
+        def hash_string(digest, str)
+          ::Base64.encode64(digest.digest(str)).chomp
         end
-        
+
       end
-      
+
     end
   end
 end

--- a/lib/mixlib/authentication/http_authentication_request.rb
+++ b/lib/mixlib/authentication/http_authentication_request.rb
@@ -64,6 +64,10 @@ module Mixlib
         headers[:x_ops_content_hash].chomp
       end
 
+      def server_api_version
+        (headers[:x_ops_server_api_version] || '0').chomp
+      end
+
       def request_signature
         unless @request_signature
           @request_signature = headers.find_all { |h| h[0].to_s =~ /^x_ops_authorization_/ }.sort { |x,y| x.to_s <=> y.to_s}.map { |i| i[1] }.join("\n")
@@ -80,8 +84,6 @@ module Mixlib
           raise MissingAuthenticationHeader, "missing required authentication header(s) '#{missing_headers.join("', '")}'"
         end
       end
-
-
     end
   end
 end

--- a/lib/mixlib/authentication/http_authentication_request.rb
+++ b/lib/mixlib/authentication/http_authentication_request.rb
@@ -65,7 +65,7 @@ module Mixlib
       end
 
       def server_api_version
-        (headers[:x_ops_server_api_version] || '0').chomp
+        (headers[:x_ops_server_api_version] || DEFAULT_SERVER_API_VERSION).chomp
       end
 
       def request_signature

--- a/lib/mixlib/authentication/signatureverification.rb
+++ b/lib/mixlib/authentication/signatureverification.rb
@@ -138,8 +138,15 @@ module Mixlib
 
       def verify_signature(algorithm, version)
         candidate_block = canonicalize_request(algorithm, version)
-        request_decrypted_block = @user_secret.public_decrypt(Base64.decode64(request_signature))
-        @valid_signature = (request_decrypted_block == candidate_block)
+        signature = Base64.decode64(request_signature)
+        @valid_signature = case version
+                           when '1.3'
+                             digest = validate_sign_version_digest!(version, algorithm)
+                             @user_secret.verify(digest.new, signature, candidate_block)
+                           else
+                             request_decrypted_block = @user_secret.public_decrypt(signature)
+                             (request_decrypted_block == candidate_block)
+                           end
 
         # Keep the debug messages lined up so it's easy to scan them
         Mixlib::Authentication::Log.debug("Verifying request signature:")

--- a/lib/mixlib/authentication/signatureverification.rb
+++ b/lib/mixlib/authentication/signatureverification.rb
@@ -171,7 +171,7 @@ module Mixlib
 
       # The request signature is based on any file attached, if any. Otherwise
       # it's based on the body of the request.
-      def hashed_body
+      def hashed_body(digest=Digest::SHA1)
         unless @hashed_body
           # TODO: tim: 2009-112-28: It'd be nice to remove this special case, and
           # always hash the entire request body. In the file case it would just be
@@ -205,11 +205,11 @@ module Mixlib
           # we hash the body.
           if file_param
             Mixlib::Authentication::Log.debug "Digesting file_param: '#{file_param.inspect}'"
-            @hashed_body = digester.hash_file(Digest::SHA1, file_param)
+            @hashed_body = digester.hash_file(digest, file_param)
           else
             body = request.raw_post
             Mixlib::Authentication::Log.debug "Digesting body: '#{body}'"
-            @hashed_body = digester.hash_string(Digest::SHA1, body)
+            @hashed_body = digester.hash_string(digest, body)
           end
         end
         @hashed_body

--- a/lib/mixlib/authentication/signatureverification.rb
+++ b/lib/mixlib/authentication/signatureverification.rb
@@ -48,6 +48,8 @@ module Mixlib
 
       def_delegator :@auth_request, :request
 
+      def_delegator :@auth_request, :server_api_version
+
       include Mixlib::Authentication::SignedHeaderAuth
 
       def initialize(request=nil)

--- a/lib/mixlib/authentication/signatureverification.rb
+++ b/lib/mixlib/authentication/signatureverification.rb
@@ -141,7 +141,7 @@ module Mixlib
         signature = Base64.decode64(request_signature)
         @valid_signature = case version
                            when '1.3'
-                             digest = validate_sign_version_digest!(version, algorithm)
+                             digest = validate_sign_version_digest!(algorithm, version)
                              @user_secret.verify(digest.new, signature, candidate_block)
                            else
                              request_decrypted_block = @user_secret.public_decrypt(signature)

--- a/lib/mixlib/authentication/signatureverification.rb
+++ b/lib/mixlib/authentication/signatureverification.rb
@@ -205,11 +205,11 @@ module Mixlib
           # we hash the body.
           if file_param
             Mixlib::Authentication::Log.debug "Digesting file_param: '#{file_param.inspect}'"
-            @hashed_body = digester.hash_file(file_param)
+            @hashed_body = digester.hash_file(Digest::SHA1, file_param)
           else
             body = request.raw_post
             Mixlib::Authentication::Log.debug "Digesting body: '#{body}'"
-            @hashed_body = digester.hash_string(body)
+            @hashed_body = digester.hash_string(Digest::SHA1, body)
           end
         end
         @hashed_body

--- a/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/mixlib/authentication/signedheaderauth.rb
@@ -99,7 +99,7 @@ module Mixlib
       # ====Parameters
       # private_key<OpenSSL::PKey::RSA>:: user's RSA private key.
       def sign(private_key, sign_algorithm=algorithm, sign_version=proto_version)
-        digest = validate_sign_version_digest!(sign_version, sign_algorithm)
+        digest = validate_sign_version_digest!(sign_algorithm, sign_version)
         # Our multiline hash for authorization will be encoded in multiple header
         # lines - X-Ops-Authorization-1, ... (starts at 1, not 0!)
         header_hash = {
@@ -121,7 +121,7 @@ module Mixlib
         header_hash
       end
 
-      def validate_sign_version_digest!(sign_version, sign_algorithm)
+      def validate_sign_version_digest!(sign_algorithm, sign_version)
         if ALGORITHMS_FOR_VERSION[sign_version].nil?
           raise AuthenticationError,
             "Unsupported version '#{sign_version}'"
@@ -191,7 +191,7 @@ module Mixlib
       #
       #
       def canonicalize_request(sign_algorithm=algorithm, sign_version=proto_version)
-        digest = validate_sign_version_digest!(sign_version, sign_algorithm)
+        digest = validate_sign_version_digest!(sign_algorithm, sign_version)
         canonical_x_ops_user_id = canonicalize_user_id(user_id, sign_version, digest)
         case sign_version
         when "1.3"

--- a/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/mixlib/authentication/signedheaderauth.rb
@@ -19,7 +19,7 @@
 
 require 'time'
 require 'base64'
-require 'digest/sha1'
+require 'openssl/digest'
 require 'mixlib/authentication'
 require 'mixlib/authentication/digester'
 
@@ -36,6 +36,7 @@ module Mixlib
       ALGORITHMS_FOR_VERSION = {
         '1.0' => ['sha1'],
         '1.1' => ['sha1'],
+        '1.3' => ['sha256', 'sha1'],
       }.freeze()
 
       DEFAULT_SIGN_ALGORITHM = 'sha1'.freeze
@@ -78,7 +79,9 @@ module Mixlib
                           args[:timestamp],
                           args[:user_id],
                           args[:file],
-                          args[:proto_version])
+                          args[:proto_version],
+                          args[:signing_algorithm]
+                         )
       end
 
       def algorithm
@@ -104,17 +107,27 @@ module Mixlib
           "X-Ops-Content-Hash" => hashed_body(digest),
         }
 
-        string_to_sign = canonicalize_request(sign_algorithm, sign_version)
-        signature = Base64.encode64(private_key.private_encrypt(string_to_sign)).chomp
+        signature = Base64.encode64(do_sign(private_key, digest, sign_algorithm, sign_version)).chomp
         signature_lines = signature.split(/\n/)
         signature_lines.each_index do |idx|
           key = "X-Ops-Authorization-#{idx + 1}"
           header_hash[key] = signature_lines[idx]
         end
 
-        Mixlib::Authentication::Log.debug "String to sign: '#{string_to_sign}'\nHeader hash: #{header_hash.inspect}"
+        Mixlib::Authentication::Log.debug "Header hash: #{header_hash.inspect}"
 
         header_hash
+      end
+
+      def do_sign(private_key, digest, sign_algorithm, sign_version)
+        string_to_sign = canonicalize_request(sign_algorithm, sign_version)
+        Mixlib::Authentication::Log.debug "String to sign: '#{string_to_sign}'"
+        case sign_version
+        when '1.3'
+          private_key.sign(digest.new, string_to_sign)
+        else
+          private_key.private_encrypt(string_to_sign)
+        end
       end
 
       def validate_sign_version_digest!(sign_version, sign_algorithm)
@@ -130,9 +143,9 @@ module Mixlib
 
         case sign_algorithm
         when 'sha1'
-          Digest::SHA1
+          OpenSSL::Digest::SHA1
         when 'sha256'
-          Digest::SHA256
+          OpenSSL::Digest::SHA256
         else
           # This case should never happen
           raise "Unknown algorithm #{sign_algorithm}"
@@ -157,7 +170,7 @@ module Mixlib
         p.length > 1 ? p.chomp('/') : p
       end
 
-      def hashed_body(digest=Digest::SHA1)
+      def hashed_body(digest=OpenSSL::Digest::SHA1)
         # This is weird. sign() is called with the digest type and signing
         # version. These are also expected to be properties of the object.
         # Hence, we're going to assume the one that is passed to sign is
@@ -187,24 +200,33 @@ module Mixlib
       #
       #
       def canonicalize_request(sign_algorithm=algorithm, sign_version=proto_version)
-
         digest = validate_sign_version_digest!(sign_version, sign_algorithm)
         canonical_x_ops_user_id = canonicalize_user_id(user_id, sign_version, digest)
-        [
-          "Method:#{http_method.to_s.upcase}",
-          "Hashed Path:#{digester.hash_string(digest, canonical_path)}",
-          "X-Ops-Content-Hash:#{hashed_body(digest)}",
-          "X-Ops-Timestamp:#{canonical_time}",
-          "X-Ops-UserId:#{canonical_x_ops_user_id}"
-        ].join("\n")
+        case sign_version
+        when "1.3"
+          [
+            "Method:#{http_method.to_s.upcase}",
+            "Hashed Path:#{digester.hash_string(digest, canonical_path)}",
+            "X-Ops-Content-Hash:#{hashed_body(digest)}",
+            "X-Ops-Sign:algorithm=#{sign_algorithm};version=#{sign_version}",
+            "X-Ops-Timestamp:#{canonical_time}",
+            "X-Ops-UserId:#{canonical_x_ops_user_id}"
+          ].join("\n")
+        else
+          [
+            "Method:#{http_method.to_s.upcase}",
+            "Hashed Path:#{digester.hash_string(digest, canonical_path)}",
+            "X-Ops-Content-Hash:#{hashed_body(digest)}",
+            "X-Ops-Timestamp:#{canonical_time}",
+            "X-Ops-UserId:#{canonical_x_ops_user_id}"
+          ].join("\n")
+        end
       end
 
-      def canonicalize_user_id(user_id, proto_version, digest=Digest::SHA1)
+      def canonicalize_user_id(user_id, proto_version, digest=OpenSSL::Digest::SHA1)
         case proto_version
-        when "1.1"
-          digester.hash_string(Digest::SHA1, user_id)
-        when "1.0"
-          user_id
+        when "1.1", "1.3"
+          digester.hash_string(digest, user_id)
         else
           user_id
         end
@@ -236,11 +258,26 @@ module Mixlib
     # A Struct-based value object that contains the necessary information to
     # generate a request signature. `SignedHeaderAuth.signing_object()`
     # provides a more convenient interface to the constructor.
-    class SigningObject < Struct.new(:http_method, :path, :body, :host, :timestamp, :user_id, :file, :proto_version)
+    class SigningObject < Struct.new(:http_method, :path, :body, :host,
+                                     :timestamp, :user_id, :file, :proto_version,
+                                     :signing_algorithm)
       include SignedHeaderAuth
 
       def proto_version
         (self[:proto_version] or DEFAULT_PROTO_VERSION).to_s
+      end
+
+      def algorithm
+        if self[:signing_algorithm]
+          self[:signing_algorithm]
+        else
+          case proto_version
+          when '1.3'
+            ALGORITHMS_FOR_VERSION[proto_version].first
+          else
+            DEFAULT_SIGN_ALGORITHM
+          end
+        end
       end
     end
 

--- a/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/mixlib/authentication/signedheaderauth.rb
@@ -30,14 +30,16 @@ module Mixlib
 
       NULL_ARG = Object.new
 
-      SUPPORTED_ALGORITHMS = ['sha1'].freeze
-      SUPPORTED_VERSIONS = ['1.0', '1.1'].freeze
-
       ALGORITHMS_FOR_VERSION = {
         '1.0' => ['sha1'],
         '1.1' => ['sha1'],
         '1.3' => ['sha256', 'sha1'],
       }.freeze()
+
+      # Use of SUPPORTED_ALGORITHMS and SUPPORTED_VERSIONS is deprecated. Use
+      # ALGORITHMS_FOR_VERSION instead
+      SUPPORTED_ALGORITHMS = ['sha1'].freeze
+      SUPPORTED_VERSIONS = ['1.0', '1.1'].freeze
 
       DEFAULT_SIGN_ALGORITHM = 'sha1'.freeze
       DEFAULT_PROTO_VERSION = '1.0'.freeze
@@ -117,17 +119,6 @@ module Mixlib
         Mixlib::Authentication::Log.debug "Header hash: #{header_hash.inspect}"
 
         header_hash
-      end
-
-      def do_sign(private_key, digest, sign_algorithm, sign_version)
-        string_to_sign = canonicalize_request(sign_algorithm, sign_version)
-        Mixlib::Authentication::Log.debug "String to sign: '#{string_to_sign}'"
-        case sign_version
-        when '1.3'
-          private_key.sign(digest.new, string_to_sign)
-        else
-          private_key.private_encrypt(string_to_sign)
-        end
       end
 
       def validate_sign_version_digest!(sign_version, sign_algorithm)
@@ -248,6 +239,18 @@ module Mixlib
 
       def digester
         Mixlib::Authentication::Digester
+      end
+
+      # private
+      def do_sign(private_key, digest, sign_algorithm, sign_version)
+        string_to_sign = canonicalize_request(sign_algorithm, sign_version)
+        Mixlib::Authentication::Log.debug "String to sign: '#{string_to_sign}'"
+        case sign_version
+        when '1.3'
+          private_key.sign(digest.new, string_to_sign)
+        else
+          private_key.private_encrypt(string_to_sign)
+        end
       end
 
       private :canonical_time, :canonical_path, :parse_signing_description, :digester, :canonicalize_user_id

--- a/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/mixlib/authentication/signedheaderauth.rb
@@ -134,7 +134,7 @@ module Mixlib
         # TODO: tim 2009-12-28: It'd be nice to just remove this special case,
         # always sign the entire request body, using the expanded multipart
         # body in the case of a file being include.
-        @hashed_body ||= (self.file && self.file.respond_to?(:read)) ? digester.hash_file(self.file) : digester.hash_string(self.body)
+        @hashed_body ||= (self.file && self.file.respond_to?(:read)) ? digester.hash_file(Digest::SHA1, self.file) : digester.hash_string(Digest::SHA1, self.body)
       end
 
       # Takes HTTP request method & headers and creates a canonical form
@@ -149,13 +149,13 @@ module Mixlib
         end
 
         canonical_x_ops_user_id = canonicalize_user_id(user_id, sign_version)
-        "Method:#{http_method.to_s.upcase}\nHashed Path:#{digester.hash_string(canonical_path)}\nX-Ops-Content-Hash:#{hashed_body}\nX-Ops-Timestamp:#{canonical_time}\nX-Ops-UserId:#{canonical_x_ops_user_id}"
+        "Method:#{http_method.to_s.upcase}\nHashed Path:#{digester.hash_string(Digest::SHA1, canonical_path)}\nX-Ops-Content-Hash:#{hashed_body}\nX-Ops-Timestamp:#{canonical_time}\nX-Ops-UserId:#{canonical_x_ops_user_id}"
       end
 
       def canonicalize_user_id(user_id, proto_version)
         case proto_version
         when "1.1"
-          digester.hash_string(user_id)
+          digester.hash_string(Digest::SHA1, user_id)
         when "1.0"
           user_id
         else

--- a/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/mixlib/authentication/signedheaderauth.rb
@@ -44,8 +44,6 @@ module Mixlib
       DEFAULT_SIGN_ALGORITHM = 'sha1'.freeze
       DEFAULT_PROTO_VERSION = '1.0'.freeze
 
-      DEFAULT_SERVER_API_VERSION = '0'
-
       # === signing_object
       # This is the intended interface for signing requests with the
       # Opscode/Chef signed header protocol. This wraps the constructor for a

--- a/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/mixlib/authentication/signedheaderauth.rb
@@ -29,8 +29,14 @@ module Mixlib
     module SignedHeaderAuth
 
       NULL_ARG = Object.new
+
       SUPPORTED_ALGORITHMS = ['sha1'].freeze
       SUPPORTED_VERSIONS = ['1.0', '1.1'].freeze
+
+      ALGORITHMS_FOR_VERSION = {
+        '1.0' => ['sha1'],
+        '1.1' => ['sha1'],
+      }.freeze()
 
       DEFAULT_SIGN_ALGORITHM = 'sha1'.freeze
       DEFAULT_PROTO_VERSION = '1.0'.freeze
@@ -88,13 +94,14 @@ module Mixlib
       # ====Parameters
       # private_key<OpenSSL::PKey::RSA>:: user's RSA private key.
       def sign(private_key, sign_algorithm=algorithm, sign_version=proto_version)
+        digest = validate_sign_version_digest!(sign_version, sign_algorithm)
         # Our multiline hash for authorization will be encoded in multiple header
         # lines - X-Ops-Authorization-1, ... (starts at 1, not 0!)
         header_hash = {
           "X-Ops-Sign" => "algorithm=#{sign_algorithm};version=#{sign_version};",
           "X-Ops-Userid" => user_id,
           "X-Ops-Timestamp" => canonical_time,
-          "X-Ops-Content-Hash" => hashed_body,
+          "X-Ops-Content-Hash" => hashed_body(digest),
         }
 
         string_to_sign = canonicalize_request(sign_algorithm, sign_version)
@@ -108,6 +115,28 @@ module Mixlib
         Mixlib::Authentication::Log.debug "String to sign: '#{string_to_sign}'\nHeader hash: #{header_hash.inspect}"
 
         header_hash
+      end
+
+      def validate_sign_version_digest!(sign_version, sign_algorithm)
+        if ALGORITHMS_FOR_VERSION[sign_version].nil?
+          raise AuthenticationError,
+            "Unsupported version '#{sign_version}'"
+        end
+
+        if !ALGORITHMS_FOR_VERSION[sign_version].include?(sign_algorithm)
+          raise AuthenticationError,
+            "Unsupported version '#{sign_version}'"
+        end
+
+        case sign_algorithm
+        when 'sha1'
+          Digest::SHA1
+        when 'sha256'
+          Digest::SHA256
+        else
+          # This case should never happen
+          raise "Unknown algorithm #{sign_algorithm}"
+        end
       end
 
       # Build the canonicalized time based on utc & iso8601
@@ -128,13 +157,27 @@ module Mixlib
         p.length > 1 ? p.chomp('/') : p
       end
 
-      def hashed_body
+      def hashed_body(digest=Digest::SHA1)
+        # This is weird. sign() is called with the digest type and signing
+        # version. These are also expected to be properties of the object.
+        # Hence, we're going to assume the one that is passed to sign is
+        # the correct one and needs to passed through all the functions
+        # that do any sort of digest.
+        if @hashed_body_digest != nil && @hashed_body_digest != digest
+          raise "hashed_body must always be called with the same digest"
+        else
+          @hashed_body_digest = digest
+        end
         # Hash the file object if it was passed in, otherwise hash based on
         # the body.
         # TODO: tim 2009-12-28: It'd be nice to just remove this special case,
         # always sign the entire request body, using the expanded multipart
         # body in the case of a file being include.
-        @hashed_body ||= (self.file && self.file.respond_to?(:read)) ? digester.hash_file(Digest::SHA1, self.file) : digester.hash_string(Digest::SHA1, self.body)
+        @hashed_body ||= if self.file && self.file.respond_to?(:read)
+                           digester.hash_file(digest, self.file)
+                         else
+                           digester.hash_string(digest, self.body)
+                         end
       end
 
       # Takes HTTP request method & headers and creates a canonical form
@@ -144,15 +187,19 @@ module Mixlib
       #
       #
       def canonicalize_request(sign_algorithm=algorithm, sign_version=proto_version)
-        unless SUPPORTED_ALGORITHMS.include?(sign_algorithm) && SUPPORTED_VERSIONS.include?(sign_version)
-          raise AuthenticationError, "Bad algorithm '#{sign_algorithm}' (allowed: #{SUPPORTED_ALGORITHMS.inspect}) or version '#{sign_version}' (allowed: #{SUPPORTED_VERSIONS.inspect})"
-        end
 
-        canonical_x_ops_user_id = canonicalize_user_id(user_id, sign_version)
-        "Method:#{http_method.to_s.upcase}\nHashed Path:#{digester.hash_string(Digest::SHA1, canonical_path)}\nX-Ops-Content-Hash:#{hashed_body}\nX-Ops-Timestamp:#{canonical_time}\nX-Ops-UserId:#{canonical_x_ops_user_id}"
+        digest = validate_sign_version_digest!(sign_version, sign_algorithm)
+        canonical_x_ops_user_id = canonicalize_user_id(user_id, sign_version, digest)
+        [
+          "Method:#{http_method.to_s.upcase}",
+          "Hashed Path:#{digester.hash_string(digest, canonical_path)}",
+          "X-Ops-Content-Hash:#{hashed_body(digest)}",
+          "X-Ops-Timestamp:#{canonical_time}",
+          "X-Ops-UserId:#{canonical_x_ops_user_id}"
+        ].join("\n")
       end
 
-      def canonicalize_user_id(user_id, proto_version)
+      def canonicalize_user_id(user_id, proto_version, digest=Digest::SHA1)
         case proto_version
         when "1.1"
           digester.hash_string(Digest::SHA1, user_id)

--- a/spec/mixlib/authentication/http_authentication_request_spec.rb
+++ b/spec/mixlib/authentication/http_authentication_request_spec.rb
@@ -125,4 +125,8 @@ SIG
     expect(@http_authentication_request.request_signature).to eq(expected.chomp)
   end
 
+  it "defaults to server api version 0" do
+    expect(@http_authentication_request.server_api_version).to eq('0')
+  end
+
 end

--- a/spec/mixlib/authentication/mixlib_authentication_spec.rb
+++ b/spec/mixlib/authentication/mixlib_authentication_spec.rb
@@ -93,6 +93,8 @@ describe "Mixlib::Authentication::SignedHeaderAuth" do
   it "should generate the correct string to sign and signature for version 1.3 with SHA1" do
     expect(V1_3_SHA1_SIGNING_OBJECT.proto_version).to eq("1.3")
     expect(V1_3_SHA1_SIGNING_OBJECT.canonicalize_request).to eq(V1_3_SHA1_CANONICAL_REQUEST)
+    expect(V1_3_SHA1_SIGNING_OBJECT.algorithm).to eq("sha1")
+    expect(V1_3_SHA1_SIGNING_OBJECT.server_api_version).to eq("1")
 
     # If you need to regenerate the constants in this test spec, print out
     # the results of res.inspect and copy them as appropriate into the
@@ -103,6 +105,7 @@ describe "Mixlib::Authentication::SignedHeaderAuth" do
   it "should generate the correct string to sign and signature for version 1.3 with SHA256" do
     expect(V1_3_SHA256_SIGNING_OBJECT.proto_version).to eq("1.3")
     expect(V1_3_SHA256_SIGNING_OBJECT.algorithm).to eq("sha256")
+    expect(V1_3_SHA256_SIGNING_OBJECT.server_api_version).to eq("1")
     expect(V1_3_SHA256_SIGNING_OBJECT.canonicalize_request).to eq(V1_3_SHA256_CANONICAL_REQUEST)
 
     # If you need to regenerate the constants in this test spec, print out
@@ -370,7 +373,10 @@ V1_3_ARGS_SHA1 = {
   :file => MockFile.new,
   :path => PATH,
   :proto_version => '1.3',
-  :signing_algorithm => 'sha1'
+  :signing_algorithm => 'sha1',
+  :headers => {
+    'X-OpS-SeRvEr-ApI-VerSiOn' => '1'
+  }
 }
 
 V1_3_ARGS_SHA256 = {
@@ -380,7 +386,10 @@ V1_3_ARGS_SHA256 = {
   :timestamp => TIMESTAMP_ISO8601,    # fixed timestamp so we get back the same answer each time.
   :file => MockFile.new,
   :path => PATH,
-  :proto_version => '1.3'
+  :proto_version => '1.3',
+  :headers => {
+    'X-OpS-SeRvEr-ApI-VerSiOn' => '1'
+  }
   # This defaults to sha256
 }
 
@@ -418,21 +427,21 @@ X_OPS_AUTHORIZATION_LINES = [
 ]
 
 X_OPS_AUTHORIZATION_LINES_V1_3_SHA1 = [
-  "wVDg3X99mxxQr1Ox/KJc+zy7b/mPX/M1+jsta5Qht43UhkNq3spRqup8vP26",
-  "TT/0pSSDnJ//wlYnxrEP+izgRGO3n4rwLQNM/ePB+dOXSiOwLDJOl7yChUde",
-  "qrxX6xsaIps6+Di/DRQ1jqLBO5KHkt8Ndc6KUeyV4Dbz/O4+8VIJw0j22Sne",
-  "6kWG648yVrS/ODeHfPGw2kLa1bQ1X7uEpNpOG2l1zzgm19wXZYllnjZphcll",
-  "lItQ/00hM7BgbSJWcqu8tShXlZUv6/ScClQZmkdN3mNojgmlt1fMv2LjejD1",
-  "8I8xfPcfBKelkz4bLHsB86pMvvE+g9tC+h2EvYU2Rw=="
+  "Dh7xqnM3HabvuPVTsJCvHSWGyipvv0xkF9u7XfomC0tDHBF8wG4kEToRI7/1",
+  "CSa97jlHLQ+VqNq76uy2mxg0PBxPLxPcz+VREJxnxEv+gEEr6MAeMpV97ip0",
+  "VICuUZ3hPIVNl9hIjmaeOnQSbtJZZOIik0g0O+bpd7AQKa/Y7r2jw42D/Kgg",
+  "L/ts6ntD2wKb92iPZ5bEXYIJFKVKb7j10PTcHLxkMWd64Cd7GZAdHHl4z8/t",
+  "VZ5XCe23960z08d2P2I+iYBBCxRCOPwafBvbt0ubls2vecraHQYYXMXovjmV",
+  "Rxh8xRaTfEhpWwZJa1ONVvsldZlvGiHO/jhmRJ9oCA=="
 ]
 
 X_OPS_AUTHORIZATION_LINES_V1_3_SHA256 = [
-  "Zo20R014Yt3IjMCsUVbOCoctwHOHaxsC3b6dPqmk3xIZo1zmOgVbsHzL72Bt",
-  "cRAeqm/gXHRNJlo4Fbh4jTJP3IBAm+mhga6aMZhRkrVUYfnZ1oEi8f/Z9WyY",
-  "uYPD8iygCEyFj2BshWsvo+lv3EvlmYlh5cKqjqaStLtGB118vfoTAf+XqK/y",
-  "tW4Ye6yn8KddnT/mLMqKJgy8PEbr+jVdLA7wDTZd64++IleNmgK72qneMEjk",
-  "4zuU5JWYfnT3MzyKR7sCsuEvxUNn/o4u5GEuuud2oP8dJUraNNUXpJYk9Us7",
-  "yZS3bUNsFPFVP3RAQadLX9gvC4eAZadTuly0wi0Edg=="
+  "BjR+iTK2eOgwmT2yGqLvE7Fp+VlpRGyL1dVoF2DmhUPO7EVsnxx2s32AmlOw",
+  "EpaACpav8SoB7K4rpOo3gfBm0XAYLnLLWzcec2OQG2O0wxxHiKVn4qWEe7Cs",
+  "RZ903DGM54t4uK75vx6wwoEdZqZe21npsLK+F3oAqnkgp+YXmlYv9Se5tFKB",
+  "0GWM1ibGJMjUIFAm7vxzjcuEvkkKN49MnXeMAAykfymcs74RU6xEKYzzSAyC",
+  "ygkV6xQSapDMp/aY29cVA/1FgZeVMhnFSTjtqBehchZYwXswr0A72A86gID9",
+  "h2QsUpmQJwbOK3bb1GptAnd5IiLzIxtu+vFeY6h4eA=="
 ]
 # We expect Mixlib::Authentication::SignedHeaderAuth#sign to return this
 # if passed the BODY above, based on version
@@ -513,6 +522,7 @@ MERB_HEADERS_V1_3_SHA1 = {
   "HTTP_X_OPS_TIMESTAMP"=>TIMESTAMP_ISO8601,
   "HTTP_X_OPS_CONTENT_HASH"=>X_OPS_CONTENT_HASH,
   "HTTP_X_OPS_USERID"=>USER_ID,
+  "HTTP_X_OPS_SERVER_API_VERSION"=>"1",
   "HTTP_X_OPS_AUTHORIZATION_1"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA1[0],
   "HTTP_X_OPS_AUTHORIZATION_2"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA1[1],
   "HTTP_X_OPS_AUTHORIZATION_3"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA1[2],
@@ -529,6 +539,7 @@ MERB_HEADERS_V1_3_SHA256 = {
   "HTTP_X_OPS_TIMESTAMP"=>TIMESTAMP_ISO8601,
   "HTTP_X_OPS_CONTENT_HASH"=>X_OPS_CONTENT_HASH_SHA256,
   "HTTP_X_OPS_USERID"=>USER_ID,
+  "HTTP_X_OPS_SERVER_API_VERSION"=>"1",
   "HTTP_X_OPS_AUTHORIZATION_1"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA256[0],
   "HTTP_X_OPS_AUTHORIZATION_2"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA256[1],
   "HTTP_X_OPS_AUTHORIZATION_3"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA256[2],
@@ -682,6 +693,7 @@ X-Ops-Content-Hash:#{HASHED_BODY}
 X-Ops-Sign:algorithm=sha1;version=1.3
 X-Ops-Timestamp:#{TIMESTAMP_ISO8601}
 X-Ops-UserId:#{DIGESTED_USER_ID}
+X-Ops-Server-API-Version:1
 EOS
 V1_3_SHA1_CANONICAL_REQUEST = V1_3_SHA1_CANONICAL_REQUEST_DATA.chomp
 
@@ -692,9 +704,9 @@ X-Ops-Content-Hash:#{HASHED_BODY_SHA256}
 X-Ops-Sign:algorithm=sha256;version=1.3
 X-Ops-Timestamp:#{TIMESTAMP_ISO8601}
 X-Ops-UserId:#{DIGESTED_USER_ID_SHA256}
+X-Ops-Server-API-Version:1
 EOS
 V1_3_SHA256_CANONICAL_REQUEST = V1_3_SHA256_CANONICAL_REQUEST_DATA.chomp
-
 
 V1_3_SHA256_SIGNING_OBJECT = Mixlib::Authentication::SignedHeaderAuth.signing_object(V1_3_ARGS_SHA256)
 V1_3_SHA1_SIGNING_OBJECT = Mixlib::Authentication::SignedHeaderAuth.signing_object(V1_3_ARGS_SHA1)

--- a/spec/mixlib/authentication/mixlib_authentication_spec.rb
+++ b/spec/mixlib/authentication/mixlib_authentication_spec.rb
@@ -90,6 +90,28 @@ describe "Mixlib::Authentication::SignedHeaderAuth" do
     expect(V1_1_SIGNING_OBJECT.sign(PRIVATE_KEY)).to eq(EXPECTED_SIGN_RESULT_V1_1)
   end
 
+  it "should generate the correct string to sign and signature for version 1.3 with SHA1" do
+    expect(V1_3_SHA1_SIGNING_OBJECT.proto_version).to eq("1.3")
+    expect(V1_3_SHA1_SIGNING_OBJECT.canonicalize_request).to eq(V1_3_SHA1_CANONICAL_REQUEST)
+
+    # If you need to regenerate the constants in this test spec, print out
+    # the results of res.inspect and copy them as appropriate into the
+    # the constants in this file.
+    expect(V1_3_SHA1_SIGNING_OBJECT.sign(PRIVATE_KEY)).to eq(EXPECTED_SIGN_RESULT_V1_3_SHA1)
+  end
+
+  it "should generate the correct string to sign and signature for version 1.3 with SHA256" do
+    expect(V1_3_SHA256_SIGNING_OBJECT.proto_version).to eq("1.3")
+    expect(V1_3_SHA256_SIGNING_OBJECT.algorithm).to eq("sha256")
+    expect(V1_3_SHA256_SIGNING_OBJECT.canonicalize_request).to eq(V1_3_SHA256_CANONICAL_REQUEST)
+
+    # If you need to regenerate the constants in this test spec, print out
+    # the results of res.inspect and copy them as appropriate into the
+    # the constants in this file.
+    expect(V1_3_SHA256_SIGNING_OBJECT.sign(PRIVATE_KEY)).to eq(EXPECTED_SIGN_RESULT_V1_3_SHA256)
+  end
+
+
   it "should generate the correct string to sign and signature for non-default proto version when used as a mixin" do
     algorithm = 'sha1'
     version = '1.1'
@@ -238,12 +260,15 @@ end
 
 USER_ID = "spec-user"
 DIGESTED_USER_ID = Base64.encode64(Digest::SHA1.new.digest(USER_ID)).chomp
+DIGESTED_USER_ID_SHA256 = Base64.encode64(Digest::SHA256.new.digest(USER_ID)).chomp
 BODY = "Spec Body"
 HASHED_BODY = "DFteJZPVv6WKdQmMqZUQUumUyRs=" # Base64.encode64(Digest::SHA1.digest("Spec Body")).chomp
+HASHED_BODY_SHA256 = "hDlKNZhIhgso3Fs0S0pZwJ0xyBWtR1RBaeHs1DrzOho="
 TIMESTAMP_ISO8601 = "2009-01-01T12:00:00Z"
 TIMESTAMP_OBJ = Time.parse("Thu Jan 01 12:00:00 -0000 2009")
 PATH = "/organizations/clownco"
 HASHED_CANONICAL_PATH = "YtBWDn1blGGuFIuKksdwXzHU9oE=" # Base64.encode64(Digest::SHA1.digest("/organizations/clownco")).chomp
+HASHED_CANONICAL_PATH_SHA256 = "Z3EsTMw/UBNY9n+q+WBWTJmeVg8hQFbdFzVWRxW4dOA="
 
 V1_0_ARGS = {
   :body => BODY,
@@ -264,6 +289,28 @@ V1_1_ARGS = {
   :proto_version => 1.1
 }
 
+V1_3_ARGS_SHA1 = {
+  :body => BODY,
+  :user_id => USER_ID,
+  :http_method => :post,
+  :timestamp => TIMESTAMP_ISO8601,    # fixed timestamp so we get back the same answer each time.
+  :file => MockFile.new,
+  :path => PATH,
+  :proto_version => '1.3',
+  :signing_algorithm => 'sha1'
+}
+
+V1_3_ARGS_SHA256 = {
+  :body => BODY,
+  :user_id => USER_ID,
+  :http_method => :post,
+  :timestamp => TIMESTAMP_ISO8601,    # fixed timestamp so we get back the same answer each time.
+  :file => MockFile.new,
+  :path => PATH,
+  :proto_version => '1.3'
+  # This defaults to sha256
+}
+
 LONG_PATH_LONG_USER_ARGS = {
   :body => BODY,
   :user_id => "A" * 200,
@@ -277,6 +324,8 @@ REQUESTING_ACTOR_ID = "c0f8a68c52bffa1020222a56b23cccfa"
 
 # Content hash is ???TODO
 X_OPS_CONTENT_HASH = "DFteJZPVv6WKdQmMqZUQUumUyRs="
+X_OPS_CONTENT_HASH_SHA256 = "hDlKNZhIhgso3Fs0S0pZwJ0xyBWtR1RBaeHs1DrzOho="
+
 X_OPS_AUTHORIZATION_LINES_V1_0 = [
 "jVHrNniWzpbez/eGWjFnO6lINRIuKOg40ZTIQudcFe47Z9e/HvrszfVXlKG4",
 "NMzYZgyooSvU85qkIUmKuCqgG2AIlvYa2Q/2ctrMhoaHhLOCWWoqYNMaEqPc",
@@ -295,6 +344,23 @@ X_OPS_AUTHORIZATION_LINES = [
 "FDlbAG7H8Dmvo+wBxmtNkszhzbBnEYtuwQqT8nM/8A=="
 ]
 
+X_OPS_AUTHORIZATION_LINES_V1_3_SHA1 = [
+  "wVDg3X99mxxQr1Ox/KJc+zy7b/mPX/M1+jsta5Qht43UhkNq3spRqup8vP26",
+  "TT/0pSSDnJ//wlYnxrEP+izgRGO3n4rwLQNM/ePB+dOXSiOwLDJOl7yChUde",
+  "qrxX6xsaIps6+Di/DRQ1jqLBO5KHkt8Ndc6KUeyV4Dbz/O4+8VIJw0j22Sne",
+  "6kWG648yVrS/ODeHfPGw2kLa1bQ1X7uEpNpOG2l1zzgm19wXZYllnjZphcll",
+  "lItQ/00hM7BgbSJWcqu8tShXlZUv6/ScClQZmkdN3mNojgmlt1fMv2LjejD1",
+  "8I8xfPcfBKelkz4bLHsB86pMvvE+g9tC+h2EvYU2Rw=="
+]
+
+X_OPS_AUTHORIZATION_LINES_V1_3_SHA256 = [
+  "Zo20R014Yt3IjMCsUVbOCoctwHOHaxsC3b6dPqmk3xIZo1zmOgVbsHzL72Bt",
+  "cRAeqm/gXHRNJlo4Fbh4jTJP3IBAm+mhga6aMZhRkrVUYfnZ1oEi8f/Z9WyY",
+  "uYPD8iygCEyFj2BshWsvo+lv3EvlmYlh5cKqjqaStLtGB118vfoTAf+XqK/y",
+  "tW4Ye6yn8KddnT/mLMqKJgy8PEbr+jVdLA7wDTZd64++IleNmgK72qneMEjk",
+  "4zuU5JWYfnT3MzyKR7sCsuEvxUNn/o4u5GEuuud2oP8dJUraNNUXpJYk9Us7",
+  "yZS3bUNsFPFVP3RAQadLX9gvC4eAZadTuly0wi0Edg=="
+]
 # We expect Mixlib::Authentication::SignedHeaderAuth#sign to return this
 # if passed the BODY above, based on version
 
@@ -321,6 +387,32 @@ EXPECTED_SIGN_RESULT_V1_1 = {
   "X-Ops-Authorization-4"=>X_OPS_AUTHORIZATION_LINES[3],
   "X-Ops-Authorization-5"=>X_OPS_AUTHORIZATION_LINES[4],
   "X-Ops-Authorization-6"=>X_OPS_AUTHORIZATION_LINES[5],
+  "X-Ops-Timestamp"=>TIMESTAMP_ISO8601
+}
+
+EXPECTED_SIGN_RESULT_V1_3_SHA1 = {
+  "X-Ops-Content-Hash"=>X_OPS_CONTENT_HASH,
+  "X-Ops-Userid"=>USER_ID,
+  "X-Ops-Sign"=>"algorithm=sha1;version=1.3;",
+  "X-Ops-Authorization-1"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA1[0],
+  "X-Ops-Authorization-2"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA1[1],
+  "X-Ops-Authorization-3"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA1[2],
+  "X-Ops-Authorization-4"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA1[3],
+  "X-Ops-Authorization-5"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA1[4],
+  "X-Ops-Authorization-6"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA1[5],
+  "X-Ops-Timestamp"=>TIMESTAMP_ISO8601
+}
+
+EXPECTED_SIGN_RESULT_V1_3_SHA256 = {
+  "X-Ops-Content-Hash"=>X_OPS_CONTENT_HASH_SHA256,
+  "X-Ops-Userid"=>USER_ID,
+  "X-Ops-Sign"=>"algorithm=sha256;version=1.3;",
+  "X-Ops-Authorization-1"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA256[0],
+  "X-Ops-Authorization-2"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA256[1],
+  "X-Ops-Authorization-3"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA256[2],
+  "X-Ops-Authorization-4"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA256[3],
+  "X-Ops-Authorization-5"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA256[4],
+  "X-Ops-Authorization-6"=>X_OPS_AUTHORIZATION_LINES_V1_3_SHA256[5],
   "X-Ops-Timestamp"=>TIMESTAMP_ISO8601
 }
 
@@ -478,6 +570,29 @@ X-Ops-UserId:#{DIGESTED_USER_ID}
 EOS
 V1_1_CANONICAL_REQUEST = V1_1_CANONICAL_REQUEST_DATA.chomp
 
+V1_3_SHA1_CANONICAL_REQUEST_DATA = <<EOS
+Method:POST
+Hashed Path:#{HASHED_CANONICAL_PATH}
+X-Ops-Content-Hash:#{HASHED_BODY}
+X-Ops-Sign:algorithm=sha1;version=1.3
+X-Ops-Timestamp:#{TIMESTAMP_ISO8601}
+X-Ops-UserId:#{DIGESTED_USER_ID}
+EOS
+V1_3_SHA1_CANONICAL_REQUEST = V1_3_SHA1_CANONICAL_REQUEST_DATA.chomp
+
+V1_3_SHA256_CANONICAL_REQUEST_DATA = <<EOS
+Method:POST
+Hashed Path:#{HASHED_CANONICAL_PATH_SHA256}
+X-Ops-Content-Hash:#{HASHED_BODY_SHA256}
+X-Ops-Sign:algorithm=sha256;version=1.3
+X-Ops-Timestamp:#{TIMESTAMP_ISO8601}
+X-Ops-UserId:#{DIGESTED_USER_ID_SHA256}
+EOS
+V1_3_SHA256_CANONICAL_REQUEST = V1_3_SHA256_CANONICAL_REQUEST_DATA.chomp
+
+
+V1_3_SHA256_SIGNING_OBJECT = Mixlib::Authentication::SignedHeaderAuth.signing_object(V1_3_ARGS_SHA256)
+V1_3_SHA1_SIGNING_OBJECT = Mixlib::Authentication::SignedHeaderAuth.signing_object(V1_3_ARGS_SHA1)
 V1_1_SIGNING_OBJECT = Mixlib::Authentication::SignedHeaderAuth.signing_object(V1_1_ARGS)
 V1_0_SIGNING_OBJECT = Mixlib::Authentication::SignedHeaderAuth.signing_object(V1_0_ARGS)
 LONG_SIGNING_OBJECT = Mixlib::Authentication::SignedHeaderAuth.signing_object(LONG_PATH_LONG_USER_ARGS)

--- a/spec/mixlib/authentication/mixlib_authentication_spec.rb
+++ b/spec/mixlib/authentication/mixlib_authentication_spec.rb
@@ -102,6 +102,10 @@ describe "Mixlib::Authentication::SignedHeaderAuth" do
     expect(V1_3_SHA1_SIGNING_OBJECT.sign(PRIVATE_KEY)).to eq(EXPECTED_SIGN_RESULT_V1_3_SHA1)
   end
 
+  it "should default to server api version 0 for version 1.3" do
+    expect(V1_3_SHA1_SIGNING_OBJECT_API0.server_api_version).to eq('0')
+  end
+
   it "should generate the correct string to sign and signature for version 1.3 with SHA256" do
     expect(V1_3_SHA256_SIGNING_OBJECT.proto_version).to eq("1.3")
     expect(V1_3_SHA256_SIGNING_OBJECT.algorithm).to eq("sha256")
@@ -710,6 +714,8 @@ V1_3_SHA256_CANONICAL_REQUEST = V1_3_SHA256_CANONICAL_REQUEST_DATA.chomp
 
 V1_3_SHA256_SIGNING_OBJECT = Mixlib::Authentication::SignedHeaderAuth.signing_object(V1_3_ARGS_SHA256)
 V1_3_SHA1_SIGNING_OBJECT = Mixlib::Authentication::SignedHeaderAuth.signing_object(V1_3_ARGS_SHA1)
+V1_3_SHA1_SIGNING_OBJECT_API0 = Mixlib::Authentication::SignedHeaderAuth.signing_object(
+  V1_3_ARGS_SHA1.dup.tap {|x| x.delete(:headers)})
 V1_1_SIGNING_OBJECT = Mixlib::Authentication::SignedHeaderAuth.signing_object(V1_1_ARGS)
 V1_0_SIGNING_OBJECT = Mixlib::Authentication::SignedHeaderAuth.signing_object(V1_0_ARGS)
 LONG_SIGNING_OBJECT = Mixlib::Authentication::SignedHeaderAuth.signing_object(LONG_PATH_LONG_USER_ARGS)


### PR DESCRIPTION
I've tried to keep the interface as close to what it was as possible. I would like to be able to drop this update in and anything that uses mixlib-authentication should grab the latest version (this will be a minor version bump).

More information about 1.3 can be found at https://github.com/chef/chef_authn/pull/21