### PR TITLE
Make hashing functions backwards compatible with mixlib-authentication 1.3

### DIFF
--- a/lib/mixlib/authentication/digester.rb
+++ b/lib/mixlib/authentication/digester.rb
@@ -17,13 +17,14 @@
 #
 
 require 'mixlib/authentication'
+require 'openssl'
 
 module Mixlib
   module Authentication
     class Digester
       class << self
 
-        def hash_file(digest, f)
+        def hash_file(f, digest=OpenSSL::Digest::SHA1)
           digester = digest.new
           buf = ""
           while f.read(16384, buf)
@@ -36,7 +37,7 @@ module Mixlib
         #
         # ====Parameters
         #
-        def hash_string(digest, str)
+        def hash_string(str, digest=OpenSSL::Digest::SHA1)
           ::Base64.encode64(digest.digest(str)).chomp
         end
 

--- a/lib/mixlib/authentication/signatureverification.rb
+++ b/lib/mixlib/authentication/signatureverification.rb
@@ -214,11 +214,11 @@ module Mixlib
           # we hash the body.
           if file_param
             Mixlib::Authentication::Log.debug "Digesting file_param: '#{file_param.inspect}'"
-            @hashed_body = digester.hash_file(digest, file_param)
+            @hashed_body = digester.hash_file(file_param, digest)
           else
             body = request.raw_post
             Mixlib::Authentication::Log.debug "Digesting body: '#{body}'"
-            @hashed_body = digester.hash_string(digest, body)
+            @hashed_body = digester.hash_string(body, digest)
           end
         end
         @hashed_body

--- a/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/mixlib/authentication/signedheaderauth.rb
@@ -177,9 +177,9 @@ module Mixlib
         # always sign the entire request body, using the expanded multipart
         # body in the case of a file being include.
         @hashed_body ||= if self.file && self.file.respond_to?(:read)
-                           digester.hash_file(digest, self.file)
+                           digester.hash_file(self.file, digest)
                          else
-                           digester.hash_string(digest, self.body)
+                           digester.hash_string(self.body, digest)
                          end
       end
 
@@ -206,7 +206,7 @@ module Mixlib
         else
           [
             "Method:#{http_method.to_s.upcase}",
-            "Hashed Path:#{digester.hash_string(digest, canonical_path)}",
+            "Hashed Path:#{digester.hash_string(canonical_path, digest)}",
             "X-Ops-Content-Hash:#{hashed_body(digest)}",
             "X-Ops-Timestamp:#{canonical_time}",
             "X-Ops-UserId:#{canonical_x_ops_user_id}"
@@ -218,7 +218,7 @@ module Mixlib
         case proto_version
         when "1.1"
           # and 1.2 if that ever gets implemented
-          digester.hash_string(digest, user_id)
+          digester.hash_string(user_id, digest)
         else
           # versions 1.0 and 1.3
           user_id

--- a/spec/mixlib/authentication/digester_spec.rb
+++ b/spec/mixlib/authentication/digester_spec.rb
@@ -1,0 +1,24 @@
+require 'mixlib/authentication/digester'
+
+describe Mixlib::Authentication::Digester do
+  context 'backcompat' do
+    # The digester API should really have been private,
+    # however oc-chef-pedant uses it.
+    let(:test_string) { 'hello' }
+    let(:test_string_checksum) { 'qvTGHdzF6KLavt4PO0gs2a6pQ00=' }
+
+    describe '#hash_file' do
+      it 'should default to use SHA1' do
+        expect(described_class.hash_file(StringIO.new(test_string))).to(
+          eq(test_string_checksum))
+      end
+    end
+
+    describe '#hash_string' do
+      it 'should default to use SHA1' do
+        expect(described_class.hash_string(test_string)).to(
+          eq(test_string_checksum))
+      end
+    end
+  end
+end


### PR DESCRIPTION
I had assumed that those functions were only used internally to
mixlib-authentication. It seems that oc-chef-pedant tests use
these functions. This patch makes the function backwards compatible
by defaulting to using SHA1 for the digester if one is not supplied