### PR TITLE
Update mixlib-authentication.gemspec

### DIFF
--- a/mixlib-authentication.gemspec
+++ b/mixlib-authentication.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.files = %w(LICENSE README.md Gemfile Rakefile NOTICE) + Dir.glob("*.gemspec") +
       Dir.glob("{lib,spec}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 
-  %w(rspec-core rspec-expectations rspec-mocks).each { |gem| s.add_dependency gem, "~> 3.2" }
+  %w(rspec-core rspec-expectations rspec-mocks).each { |gem| s.add_development_dependency gem, "~> 3.2" }
   s.add_development_dependency "rake", "~> 10.4"
 end


### PR DESCRIPTION
fix rspec deps being added as runtime deps

they were added via 93d555012c0ac0e53ec672fda610a114953c37ce
which refers to #7

looks like mistake