### PR TITLE
Fix SignedObject::DEFAULT_SERVER_API_VERSION constant scope

### DIFF
--- a/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/mixlib/authentication/signedheaderauth.rb
@@ -266,6 +266,7 @@ module Mixlib
     SigningObject = Struct.new(:http_method, :path, :body, :host,
                                      :timestamp, :user_id, :file, :proto_version,
                                      :headers) do
+
       include SignedHeaderAuth
 
       def proto_version
@@ -279,7 +280,7 @@ module Mixlib
         if key
           self[:headers][key]
         else
-          SignedHeaderAuth::DEFAULT_SERVER_API_VERSION
+          DEFAULT_SERVER_API_VERSION
         end
       end
     end


### PR DESCRIPTION
The `DEFAULT_SERVER_API_VERSION` is not a constant of the `SignedHeaderAuth`
module. Rather than forcing the constant lookup in that module we'll
remove the namespace and allow the Ruby constant lookup to handle it for
us. This resolves a bug where the constant lookup fails when
mixlib-authentication is vendored into other projects.