### PR TITLE
Support signing with ssh-agent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gemspec
 group(:development) do
   gem "pry"
   gem "mixlib-log"
+  gem "net-ssh"
 end

--- a/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/mixlib/authentication/signedheaderauth.rb
@@ -264,7 +264,7 @@ module Mixlib
               raise AuthenticationError, "Could not connect to ssh-agent. Make sure the SSH_AUTH_SOCK environment variable is set properly! (#{e.class.name}: #{e.message})"
             end
             begin
-              ssh2_signature = agent.sign(keypair.public_key, string_to_sign)
+              ssh2_signature = agent.sign(keypair.public_key, string_to_sign, Net::SSH::Authentication::Agent::SSH_AGENT_RSA_SHA2_256)
             rescue => e
               raise AuthenticationError, "Ssh-agent could not sign your request. Make sure your key is loaded with ssh-add! (#{e.class.name}: #{e.message})"
             end

--- a/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/mixlib/authentication/signedheaderauth.rb
@@ -279,7 +279,8 @@ module Mixlib
         rescue => e
           raise AuthenticationError, "Unable to sign request with ssh-agent. Make sure your key is loaded with ssh-add! (#{e.class.name}: #{e.message})"
         end
-        # extract signature from SSH Agent response => skip first 15 bytes for RSA keys
+        # extract signature from SSH Agent response => skip first 20 bytes for RSA keys
+        # "\x00\x00\x00\frsa-sha2-256\x00\x00\x01\x00"
         # (see http://api.libssh.org/rfc/PROTOCOL.agent for details)
         ssh2_signature[20..-1]
       end

--- a/mixlib-authentication.gemspec
+++ b/mixlib-authentication.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |s|
   s.email = "info@chef.io"
   s.homepage = "https://www.chef.io"
 
+  s.add_dependency "net-ssh"
+
   s.require_path = "lib"
   s.files = %w{LICENSE README.md Gemfile Rakefile NOTICE} + Dir.glob("*.gemspec") +
     Dir.glob("{lib,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }

--- a/mixlib-authentication.gemspec
+++ b/mixlib-authentication.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.email = "info@chef.io"
   s.homepage = "https://www.chef.io"
 
-  s.add_dependency "net-ssh"
-
   s.require_path = "lib"
   s.files = %w{LICENSE README.md Gemfile Rakefile NOTICE} + Dir.glob("*.gemspec") +
     Dir.glob("{lib,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }

--- a/spec/mixlib/authentication/mixlib_authentication_spec.rb
+++ b/spec/mixlib/authentication/mixlib_authentication_spec.rb
@@ -138,7 +138,6 @@ describe "Mixlib::Authentication::SignedHeaderAuth" do
   end
 
   it "should choke when signing a request via ssh-agent and ssh-agent is not reachable with version 1.3" do
-    expect { Net::SSH::Authentication::Agent.connect }.to raise_error(Net::SSH::Authentication::AgentNotAvailable)
     expect { V1_3_SHA256_SIGNING_OBJECT.sign(PUBLIC_KEY) }.to raise_error(Mixlib::Authentication::AuthenticationError)
   end
 


### PR DESCRIPTION
Following the release of net-ssh 4.2.0 this can be used to support signing requests with ssh-agent. In the time since I originally prepared this and the release of that gem, the mixlib-log dependency was removed here towards the goal of having no dependencies. I'm not sure how to support this in light of that but I'm open to any suggestions.