### PR TITLE
Silence the warning for the default positional args case

### DIFF
--- a/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/mixlib/authentication/signedheaderauth.rb
@@ -109,7 +109,7 @@ module Mixlib
           opts[:sign_version] ||= sign_version
         else
           # Was called like sign(key, 'foo', '1.3', other: 'bar')
-          Mixlib::Authentication.logger.warn("Using deprecated positional arguments for sign(), please update to keyword arguments (from #{caller[1][/^(.*:\d+):in /, 1]})")
+          Mixlib::Authentication.logger.warn("Using deprecated positional arguments for sign(), please update to keyword arguments (from #{caller[1][/^(.*:\d+):in /, 1]})") unless sign_algorithm == algorithm
           opts[:sign_algorithm] ||= sign_algorithm
           opts[:sign_version] ||= sign_version
         end


### PR DESCRIPTION
Make the warning less annoying for cases of `sign(key)` with no other args.