### PR TITLE
Add back Ruby 2.4 support / update testing

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -15,7 +15,10 @@ github:
   version_tag_format: "v{{version}}"
   # allow bumping the minor release via label
   minor_bump_labels:
-    - "Expeditor: Bump Minor Version"
+    - "Expeditor: Bump Version Minor"
+  # allow bumping the major release via label
+  major_bump_labels:
+    - "Expeditor: Bump Version Major"
 
 changelog:
   rollup_header: Changes not yet released to rubygems.org
@@ -30,7 +33,7 @@ merge_actions:
       only_if: built_in:bump_version
   - built_in:update_changelog:
       ignore_labels:
-        - "Expeditor: Exclude From Changelog"
+        - "Expeditor: Skip Changelog"
         - "Expeditor: Skip All"
   - built_in:build_gem:
       only_if: built_in:bump_version

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*               @chef/client-maintainers
-.expeditor/**   @chef/jex-team
+*                 @chef/chef-infra-reviewers
+.expeditor/**     @chef/jex-team
+*.md              @chef/docs-team

--- a/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
@@ -1,8 +1,16 @@
+---
+name: � Bug Report
+about: If something isn't working as expected �.
+labels: "Status: Untriaged"
+---
+
 # Version:
 
 [Version of the project installed]
 
-# Environment: [Details about the environment such as the Operating System, cookbook details, etc...]
+# Environment:
+
+[Details about the environment such as the Operating System, cookbook details, etc...]
 
 # Scenario:
 

--- a/.github/ISSUE_TEMPLATE/DESIGN_PROPOSAL.md
+++ b/.github/ISSUE_TEMPLATE/DESIGN_PROPOSAL.md
@@ -1,0 +1,40 @@
+---
+name: Design Proposal
+about: I have a significant change I would like to propose and discuss before starting
+labels: "Status: Untriaged"
+---
+
+### When a Change Needs a Design Proposal
+
+A design proposal should be opened any time a change meets one of the following qualifications:
+
+- Significantly changes the user experience of a project in a way that impacts users.
+- Significantly changes the underlying architecture of the project in a way that impacts other developers.
+- Changes the development or testing process of the project such as a change of CI systems or test frameworks.
+
+### Why We Use This Process
+
+- Allows all interested parties (including any community member) to discuss large impact changes to a project.
+- Serves as a durable paper trail for discussions regarding project architecture.
+- Forces design discussions to occur before PRs are created.
+- Reduces PR refactoring and rejected PRs.
+
+---
+
+<!---  Proposal description and rationale.  -->
+
+## Motivation
+
+<!---
+    As a <<user_profile>>,
+    I want to <<functionality>>,
+    so that <<benefit>>.
+ -->
+
+## Specification
+
+<!---  A detailed description of the planned implementation. -->
+
+## Downstream Impact
+
+<!---  Which other tools will be impacted by this work?  -->

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT_REQUEST_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+---
+name: 🚀 Enhancement Request
+about: I have a suggestion (and may want to implement it 🙂)!
+labels: "Status: Untriaged"
+---
+
+### Describe the Enhancement:
+<!---  What you are trying to achieve that you can't? -->
+
+### Describe the Need:
+<!---  What kind of user do you believe would utilize this enhancement, and how many users might want this functionality -->
+
+### Current Alternative
+<!--- Is there a current alternative that you can utilize to workaround the lack of this enhancement -->
+
+### Can We Help You Implement This?:
+<!---  The best way to ensure your enhancement is built is to help implement the enhancement yourself. If you're interested in helping out we'd love to give you a hand to make this possible. Let us know if there's something you need. -->

--- a/.github/ISSUE_TEMPLATE/SUPPORT_QUESTION.md
+++ b/.github/ISSUE_TEMPLATE/SUPPORT_QUESTION.md
@@ -1,0 +1,11 @@
+---
+name: 🤗 Support Question
+about: If you have a question 💬, please check out our Slack!
+---
+
+We use GitHub issues to track bugs and feature requests. If you need help please post to our Mailing List or join the Chef Community Slack.
+
+ * Chef Community Slack at http://community-slack.chef.io/.
+ * Chef Mailing List https://discourse.chef.io/
+
+ Support issues opened here will be closed and redirected to Slack or Discourse.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,10 +5,11 @@
 ### Issues Resolved
 
 [List any existing issues this PR resolves, or any Discourse or
-StackOverflow discussion that's relevant]
+StackOverflow discussions that are relevant]
 
 ### Check List
 
 - [ ] New functionality includes tests
 - [ ] All tests pass
 - [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
+- [ ] PR title is a worthy inclusion in the CHANGELOG

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,1 @@
+daysUntilLock: 60

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,25 @@
 language: ruby
 cache: bundler
-distro: xenial
+dist: xenial
 
 before_install:
-  - gem install bundler
+  - gem install bundler || true
   - bundle --version
   - gem update --system
   - gem --version
 
 matrix:
   include:
-    - rvm: 2.5.3
-    - rvm: 2.6.0
+    - rvm: 2.4.5
+    - rvm: 2.5.5
+    - rvm: 2.6.2
     - rvm: ruby-head
   allow_failures:
     - rvm: ruby-head
 
 branches:
   only:
-  - master
+    - master
 
 bundler_args: --without docs development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please refer to https://github.com/chef/chef/blob/master/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For information on contributing to this project please see our [Contributing Doc
 
 ## License & Copyright
 
-- Copyright:: Copyright (c) 2009-2018 Chef Software, Inc.
+- Copyright:: Copyright (c) 2009-2019 Chef Software, Inc.
 - License:: Apache License, Version 2.0
 
 ```text

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,9 @@ cache:
 
 environment:
   matrix:
+    - ruby_version: "24-x64"
     - ruby_version: "25-x64"
+    - ruby_version: "26-x64"
 
 clone_depth: 1
 skip_tags: true

--- a/mixlib-authentication.gemspec
+++ b/mixlib-authentication.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.author = "Chef Software, Inc."
   s.email = "info@chef.io"
   s.homepage = "https://github.com/chef/mixlib-authentication"
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 2.4"
 
   s.files = %w{LICENSE} + Dir.glob("lib/**/*")
   s.require_paths = ["lib"]


### PR DESCRIPTION
Add back Ruby 2.4 support
Test on more versions in Appveyor
Test on the latest ruby versions in Travis
Add our full set of GitHub templates
Enable issue locking
Add a contributing file

Signed-off-by: Tim Smith <tsmith@chef.io>