### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/mixlib/authentication.rb
+++ b/lib/mixlib/authentication.rb
@@ -36,7 +36,7 @@ module Mixlib
       require "mixlib/log"
       Mixlib::Authentication::Log.extend(Mixlib::Log)
     rescue LoadError
-      require "mixlib/authentication/null_logger"
+      require_relative "authentication/null_logger"
       Mixlib::Authentication::Log.extend(Mixlib::Authentication::NullLogger)
     end
 

--- a/lib/mixlib/authentication/digester.rb
+++ b/lib/mixlib/authentication/digester.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "mixlib/authentication"
+require_relative "../authentication"
 require "openssl"
 
 module Mixlib

--- a/lib/mixlib/authentication/http_authentication_request.rb
+++ b/lib/mixlib/authentication/http_authentication_request.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "mixlib/authentication"
+require_relative "../authentication"
 
 module Mixlib
   module Authentication

--- a/lib/mixlib/authentication/signatureverification.rb
+++ b/lib/mixlib/authentication/signatureverification.rb
@@ -19,9 +19,9 @@
 
 require "net/http"
 require "forwardable"
-require "mixlib/authentication"
-require "mixlib/authentication/http_authentication_request"
-require "mixlib/authentication/signedheaderauth"
+require_relative "../authentication"
+require_relative "http_authentication_request"
+require_relative "signedheaderauth"
 
 module Mixlib
   module Authentication

--- a/lib/mixlib/authentication/signedheaderauth.rb
+++ b/lib/mixlib/authentication/signedheaderauth.rb
@@ -20,8 +20,8 @@
 require "time"
 require "base64"
 require "openssl/digest"
-require "mixlib/authentication"
-require "mixlib/authentication/digester"
+require_relative "../authentication"
+require_relative "digester"
 
 module Mixlib
   module Authentication


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>